### PR TITLE
Automatically adjust colored area in mini-map

### DIFF
--- a/src/main/kotlin/kotcity/ui/GameFrame.kt
+++ b/src/main/kotlin/kotcity/ui/GameFrame.kt
@@ -20,6 +20,7 @@ import kotcity.ui.Tool.*
 import kotcity.ui.charts.SupplyDemandChart
 import kotcity.ui.layers.TrafficAnimationRenderer
 import kotcity.ui.layers.ZotRenderer
+import kotcity.ui.map.CityCanvas
 import kotcity.ui.map.CityMapCanvas
 import kotcity.ui.map.CityRenderer
 import kotcity.util.Debuggable
@@ -58,7 +59,7 @@ enum class GameSpeed(val tickPeriod: Long) {
 class GameFrame : View(), Debuggable {
     override var debug: Boolean = false
     override val root: BorderPane by fxml("/GameFrame.fxml")
-    private val cityCanvas = ResizableCanvas()
+    private val cityCanvas = CityCanvas()
     private val trafficCanvas = ResizableCanvas()
     private val zotCanvas = ResizableCanvas()
 
@@ -183,6 +184,7 @@ class GameFrame : View(), Debuggable {
 
         // clean up the old renderers here...
         this.cityRenderer?.removePanListeners()
+        this.cityCanvas?.clearSizeChangeListeners()
         this.trafficRenderer?.stop()
         this.zotRenderer?.stop()
 

--- a/src/main/kotlin/kotcity/ui/map/CityCanvas.kt
+++ b/src/main/kotlin/kotcity/ui/map/CityCanvas.kt
@@ -1,0 +1,27 @@
+package kotcity.ui.map
+
+import kotcity.ui.ResizableCanvas
+
+
+class CityCanvas : ResizableCanvas() {
+    private val sizeChangeListeners = ArrayList<(cityCanvas: CityCanvas) -> Unit>()
+
+    init {
+        widthProperty().addListener { observable, oldValue, newValue -> fireSizeChanged() }
+        heightProperty().addListener { observable, oldValue, newValue -> fireSizeChanged() }
+    }
+
+    fun addSizeChangeListener(listener: (cityCanvas: CityCanvas) -> Unit) {
+        sizeChangeListeners.add(listener)
+    }
+
+    fun clearSizeChangeListeners() {
+        sizeChangeListeners.clear()
+    }
+
+    private fun fireSizeChanged() {
+        for (listener in sizeChangeListeners) {
+            listener(this)
+        }
+    }
+}

--- a/src/main/kotlin/kotcity/ui/map/CityRenderer.kt
+++ b/src/main/kotlin/kotcity/ui/map/CityRenderer.kt
@@ -1,5 +1,6 @@
 package kotcity.ui.map
 
+import javafx.beans.value.ObservableValue
 import javafx.scene.Cursor
 import javafx.scene.input.MouseButton
 import javafx.scene.input.MouseEvent
@@ -20,7 +21,7 @@ import kotlin.math.pow
 
 class CityRenderer(
     private val gameFrame: GameFrame,
-    val canvas: ResizableCanvas,
+    val canvas: CityCanvas,
     private val cityMap: CityMap
 ) {
 
@@ -75,10 +76,13 @@ class CityRenderer(
 
     private val panListeners: MutableList<(Pair<BlockCoordinate, BlockCoordinate>) -> Unit> = mutableListOf()
 
+    private val sizeChangedListener = {observable: ObservableValue<out Number>, oldValue: Number, newValue: Number -> firePanChanged() }
+
     init {
         mapMinElevation = cityMap.groundLayer.values.map { it.elevation }.min() ?: 0.0
         mapMaxElevation = cityMap.groundLayer.values.map { it.elevation }.max() ?: 0.0
         colorAdjuster = ColorAdjuster(mapMinElevation, mapMaxElevation)
+        canvas.addSizeChangeListener {firePanChanged()}
     }
 
     // awkward... we need padding to get building off the screen...


### PR DESCRIPTION
Automatically adjust the colored area inside the minimap whenever the size of the city canvas is changed. This wasn't noticed before, because it is not considered a panning event.