### PR TITLE
Error handling when loading

### DIFF
--- a/src/main/kotlin/kotcity/ui/CityLoader.kt
+++ b/src/main/kotlin/kotcity/ui/CityLoader.kt
@@ -28,23 +28,20 @@ object CityLoader {
                 view.currentWindow?.let { window ->
                     val workDialog = WorkIndicatorDialog<File>(window, "Loading City...")
 
-                    val launchScreen = find(LaunchScreen::class)
-                    launchScreen.close()
-                    view.close()
-                    view.currentStage?.close()
-                    view.primaryStage.close()
-
                     workDialog.exec(
                             file,
                             ToIntFunction<File> {
                                 val map = CityFileAdapter.load(it)
                                 runLater {
+                                    closeLaunchScreen()
+
                                     val gameFrame = tornadofx.find(GameFrame::class)
                                     gameFrame.setMap(map)
                                     gameFrame.currentStage?.isMaximized = true
                                     gameFrame.openWindow()
                                     println("Gameframe should be open at this point...")
                                     gameFrame.currentStage?.isMaximized = true
+
                                     // clean up orphaned objects....
                                     System.gc()
                                 }
@@ -54,9 +51,6 @@ object CityLoader {
                                 // log exception just in case
                                 println("Handling exception:")
                                 it.printStackTrace()
-
-                                // restore launch screen
-                                restoreLaunchScreen()
 
                                 // show error message to user
                                 val alert = Alert(AlertType.ERROR)
@@ -74,8 +68,8 @@ object CityLoader {
         }
     }
 
-    private fun restoreLaunchScreen() {
+    private fun closeLaunchScreen() {
         val launchScreen = find(LaunchScreen::class)
-        launchScreen.openWindow()
+        launchScreen.close()
     }
 }

--- a/src/main/kotlin/kotcity/ui/CityLoader.kt
+++ b/src/main/kotlin/kotcity/ui/CityLoader.kt
@@ -9,6 +9,7 @@ import tornadofx.View
 import tornadofx.find
 import tornadofx.runLater
 import java.io.File
+import java.util.function.Consumer
 import java.util.function.ToIntFunction
 
 
@@ -33,32 +34,48 @@ object CityLoader {
                     view.currentStage?.close()
                     view.primaryStage.close()
 
-                    workDialog.exec(file, func = ToIntFunction<File> {
-                        val map = CityFileAdapter.load(file)
-                        runLater {
-                            val gameFrame = tornadofx.find(GameFrame::class)
-                            gameFrame.setMap(map)
-                            gameFrame.currentStage?.isMaximized = true
-                            gameFrame.openWindow()
-                            println("Gameframe should be open at this point...")
-                            gameFrame.currentStage?.isMaximized = true
-                            // clean up orphaned objects....
-                            System.gc()
-                        }
-                        1
-                    })
-                }
-            } else {
-                val alert = Alert(AlertType.ERROR)
-                alert.title = "Error during load"
-                alert.headerText = "Could not load your city!"
-                alert.contentText = "Why not? Totally unknown?"
-                val stage = alert.dialogPane.scene.window as Stage
-                stage.isAlwaysOnTop = true
-                stage.toFront() // not sure if necessary
+                    workDialog.exec(
+                            file,
+                            ToIntFunction<File> {
+                                val map = CityFileAdapter.load(it)
+                                runLater {
+                                    val gameFrame = tornadofx.find(GameFrame::class)
+                                    gameFrame.setMap(map)
+                                    gameFrame.currentStage?.isMaximized = true
+                                    gameFrame.openWindow()
+                                    println("Gameframe should be open at this point...")
+                                    gameFrame.currentStage?.isMaximized = true
+                                    // clean up orphaned objects....
+                                    System.gc()
+                                }
+                                1
+                            },
+                            Consumer {
+                                // log exception just in case
+                                println("Handling exception:")
+                                it.printStackTrace()
 
-                alert.showAndWait()
+                                // restore launch screen
+                                restoreLaunchScreen()
+
+                                // show error message to user
+                                val alert = Alert(AlertType.ERROR)
+                                alert.title = "Error during load"
+                                alert.headerText = "Could not load your city!"
+                                alert.contentText = "Why not? Exception is: " + it.message
+                                val stage = alert.dialogPane.scene.window as Stage
+                                stage.isAlwaysOnTop = true
+                                stage.toFront() // not sure if necessary
+                                alert.showAndWait()
+                                System.gc()
+                            })
+                }
             }
         }
+    }
+
+    private fun restoreLaunchScreen() {
+        val launchScreen = find(LaunchScreen::class)
+        launchScreen.openWindow()
     }
 }

--- a/src/main/kotlin/kotcity/ui/GameFrame.kt
+++ b/src/main/kotlin/kotcity/ui/GameFrame.kt
@@ -169,6 +169,9 @@ class GameFrame : View(), Debuggable {
     }
 
     fun setMap(cityMap: CityMap) {
+        if (::map.isInitialized) {
+            map.purgeRTree()
+        }
         this.map = cityMap
         cityMapCanvas.map = cityMap
         this.assetManager = AssetManager(cityMap)
@@ -391,10 +394,6 @@ class GameFrame : View(), Debuggable {
     fun loadCityPressed() {
         // TODO: wrap this with a dialog...
         // we will just be loading...
-        this.map.purgeRTree()
-        this.currentStage?.close()
-        renderTimer?.stop()
-        gameTickTask?.cancel()
         CityLoader.loadCity(this)
         title = "$GAME_TITLE - ${map.cityName}"
     }

--- a/src/main/kotlin/kotcity/ui/WorkIndicatorDialog.kt
+++ b/src/main/kotlin/kotcity/ui/WorkIndicatorDialog.kt
@@ -28,7 +28,7 @@ import java.util.function.ToIntFunction
  * P = Input parameter type. Given to the closure as parameter. Return type is always Integer.
  * (cc) @imifos
  */
-class WorkIndicatorDialog<in P>(owner: Window, label: String) {
+class WorkIndicatorDialog<P>(owner: Window, label: String) {
 
     private var animationWorker: Task<*>? = null
     private var taskWorker: Task<Int>? = null
@@ -71,7 +71,7 @@ class WorkIndicatorDialog<in P>(owner: Window, label: String) {
      * @param parameter An input parameter for the payload function
      * @param func The payload function which should be executed
      */
-    fun exec(parameter: P, func: ToIntFunction<*>) {
+    fun exec(parameter: P, func: ToIntFunction<P>) {
         exec(parameter, func, Consumer {throw it} )
     }
 
@@ -82,10 +82,10 @@ class WorkIndicatorDialog<in P>(owner: Window, label: String) {
      * @param func The payload function which should be executed
      * @param errFunc The error handling function, which will be called in case an exception occurs
      */
-    fun exec(parameter: P, func: ToIntFunction<*>, errFunc: Consumer<Exception>) {
+    fun exec(parameter: P, func: ToIntFunction<P>, errFunc: Consumer<Exception>) {
         setupDialog()
         setupAnimationThread()
-        setupWorkerThread(parameter, func as ToIntFunction<P>, errFunc)
+        setupWorkerThread(parameter, func, errFunc)
     }
 
     /**


### PR DESCRIPTION
Goals: 

1.) When the user attempts to load a new city but then cancels, the game should just continue from where it was interrupted (instead of showing an error message)

2.) When the user actually tries to open a corrupted file, there should be an error message and afterwards the game should continue from where it was interrupted

[x] Achieved the described behavior for loading a city from the main menu
[x] Achieved the described behavior for loading a city from a the menu inside the game screen